### PR TITLE
Modified impactStory constructor to still work if invoked without 'new'

### DIFF
--- a/ImpactStory.js
+++ b/ImpactStory.js
@@ -5,7 +5,13 @@ var ImpactStory = new impactStory();
 // If you don't want to use the global object, you can create a new impactStory object by using `var myIS = new impactStory()`.
 function impactStory() {
 
-  var self = this;
+  var self;
+
+  if (! (this instanceof impactStory)) {
+    return new impactStory();
+  }
+
+  self = this;
 
   // This should be overriden. An error will be thrown if a key is not set.
   self.key = '';


### PR DESCRIPTION
Sometimes the 'new' keyword is erroneously omitted when invoking a constructor. If so, 'this' within the constructor function refers to the global object, and not the (expected) object returned by the constructor. Then things break.

This commit bulletproofs the impactStory constructor against being invoked without 'new'. Before the constructor does anything else, it checks whether 'this' is an instance of impactStory (expected), and if it's not, it internally invokes "new impactStory()", thus setting 'this' to the expected value.